### PR TITLE
fix topology view delete all option and allow removing all resources in dropdown of topology  view

### DIFF
--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -558,7 +558,7 @@ const PolicyTopologyPage: React.FC = () => {
 
           // If the user has not yet set any filter, default to those in the showByDefault set
           let newSelected = selectedResourceTypes.filter((r) => uniqueTypes.includes(r));
-          if (selectedResourceTypes.length === 0) {
+          if (selectedResourceTypes.length === 0 && isInitialLoad) {
             newSelected = uniqueTypes.filter((t) => showByDefault.has(t));
             setSelectedResourceTypes(newSelected);
           }


### PR DESCRIPTION
closes #266